### PR TITLE
Add form validation for ill-formed authenticator/participant lists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
+  gem "rails-controller-testing"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,10 @@ GEM
       activesupport (= 7.0.7.2)
       bundler (>= 1.15.0)
       railties (= 7.0.7.2)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -259,6 +263,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.6.7)
   rails (>= 7.0.7.1)
+  rails-controller-testing
   rspec-rails
   selenium-webdriver
   sprockets-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -69,3 +69,6 @@ input[type='file']:hover { cursor: pointer }
 .ordered-credential .details p { margin: 0em; padding: 0em; padding-bottom: 0.5em; }
 .ordered-credential .details ul { margin: 0em; padding: 0em; list-style-type: none; }
 .ordered-credential .details ul li { margin: 0em; padding: 0em; }
+
+.invalid-border { border: 1px solid red; }
+.invalid-message { color: red; }

--- a/app/models/name_and_email.rb
+++ b/app/models/name_and_email.rb
@@ -1,13 +1,22 @@
 class NameAndEmail
   attr_reader :name, :email
 
+  EXPECTED_PATTERN = /\A(.*) <(.*)>\z/
+
   def initialize(name:, email:)
     @name = name
     @email = email
   end
 
   def self.parse(row)
-    matches = /\A(.*) <(.*)>\z/.match(row)
+    matches = EXPECTED_PATTERN.match(row)
     new(name: matches[1], email: matches[2])
+  end
+
+  def self.invalid?(blob)
+    return false if blob.empty?
+
+    lines = blob.split("\n").reject(&:empty?)
+    lines.any? { |l| EXPECTED_PATTERN !~ l }
   end
 end

--- a/app/views/credentials_for_others/add_participants_form.html.erb
+++ b/app/views/credentials_for_others/add_participants_form.html.erb
@@ -19,7 +19,10 @@
         <%= form_with url: add_participants_credentials_for_other_path do |form| %>
             <div class="field">
                 <%= form.label :participants, "Participants, one per line, as 'name <email>':" %><br/>
-                <%= form.text_area :participants %>
+                <%= form.text_area :participants, class: "#{'invalid-border' if @invalid_participants}", value: params[:participants] %>
+                <% if @invalid_participants %>
+                    <div class="invalid-message">Participants must be one per line in the form 'name &lt;email&gt;'</div>
+                <% end  %>
             </div>
 
 

--- a/app/views/credentials_for_others/new.html.erb
+++ b/app/views/credentials_for_others/new.html.erb
@@ -5,7 +5,10 @@
 <%= form_with url: credentials_for_others_path do |form| %>
     <div class="field">
         <%= form.label :name, "Name:" %><br/>
-        <%= form.text_field :name  %>
+        <%= form.text_field :name, value: params[:name], class: "#{'invalid-border' if @invalid_name}" %>
+        <% if @invalid_name  %>
+            <div class="invalid-message">Name cannot be blank</div>
+        <% end %>
     </div>
 
     <div class="field">
@@ -13,12 +16,12 @@
         <%= form.select :type, [["Education", "EducationCredential"],
                                 ["General", "GeneralCredential"],
                                 ["Work", "WorkCredential"]],
-         selected: "GeneralCredential" %>
+         selected: "#{params[:type] || 'GeneralCredential'}" %>
     </div>
 
     <div class="field">
         <%= form.label :description, "Description:" %><br/>
-        <%= form.text_area :description %>
+        <%= form.text_area :description, value: params['description'] %>
     </div>
 
     <div class="field">
@@ -30,7 +33,10 @@
 
     <div class="field">
         <%= form.label :participants, "(optional) Participants, one per line, as 'name <email>'" %><br/>
-        <%= form.text_area :participants %>
+        <%= form.text_area :participants, class: "#{'invalid-border' if @invalid_participants}", value: params[:participants] %>
+        <% if @invalid_participants %>
+            <div class="invalid-message">Participants must be one per line in the form 'name &lt;email&gt;'</div>
+        <% end  %>
     </div>
 
     <div class="actions">

--- a/app/views/my_credentials/add_authenticators_form.html.erb
+++ b/app/views/my_credentials/add_authenticators_form.html.erb
@@ -20,7 +20,10 @@
 <%= form_with url: add_authenticators_my_credential_path do |form| %>
     <div class="field">
         <%= form.label :authenticators, "Authenticators, one per line, as 'name <email>':" %><br/>
-        <%= form.text_area :authenticators %>
+        <%= form.text_area :authenticators, class: "#{'invalid-border' if @invalid_authenticators}", value: params[:authenticators] %>
+        <% if @invalid_authenticators %>
+            <div class="invalid-message">Authenticators must be one per line in the form 'name &lt;email&gt;'</div>
+        <% end  %>
     </div>
 
     <div class="actions">

--- a/app/views/my_credentials/new.html.erb
+++ b/app/views/my_credentials/new.html.erb
@@ -5,7 +5,10 @@
 <%= form_with url: my_credentials_path do |form| %>
     <div class="field">
         <%= form.label :name, "Name:" %><br/>
-        <%= form.text_field :name  %>
+        <%= form.text_field :name, value: params[:name], class: "#{'invalid-border' if @invalid_name}" %>
+        <% if @invalid_name  %>
+            <div class="invalid-message">Name cannot be blank</div>
+        <% end %>
     </div>
 
     <div class="field">
@@ -13,12 +16,12 @@
         <%= form.select :type, [["Education", "EducationCredential"],
                                 ["General", "GeneralCredential"],
                                 ["Work", "WorkCredential"]],
-                               selected: "GeneralCredential" %>
+                               selected: "#{params[:type] || 'GeneralCredential'}" %>
     </div>
 
     <div class="field">
         <%= form.label :description, "Description:" %><br/>
-        <%= form.text_area :description %>
+        <%= form.text_area :description, value: params['description'] %>
     </div>
 
     <div class="field">
@@ -30,7 +33,10 @@
 
     <div class="field">
         <%= form.label :authenticators, "(optional) Authenticators, one per line, as 'name <email>':" %><br/>
-        <%= form.text_area :authenticators %>
+        <%= form.text_area :authenticators, class: "#{'invalid-border' if @invalid_authenticators}", value: params[:authenticators] %>
+        <% if @invalid_authenticators %>
+            <div class="invalid-message">Authenticators must be one per line in the form 'name &lt;email&gt;'</div>
+        <% end  %>
     </div>
 
     <div class="actions">

--- a/spec/models/name_and_email_spec.rb
+++ b/spec/models/name_and_email_spec.rb
@@ -8,4 +8,21 @@ RSpec.describe NameAndEmail do
       expect(actual.email).to eq ("email")
     end
   end
+  describe "invalid?" do
+    it "empty is false (it's an optional field)" do
+      expect(NameAndEmail.invalid?("")).to be false
+    end
+    it "blank line should resolve to empty" do
+      expect(NameAndEmail.invalid?("\n")).to be false
+    end
+    it "one valid line is false" do
+      expect(NameAndEmail.invalid?("name <email>")).to be false
+    end
+    it "one invalid line is true" do
+      expect(NameAndEmail.invalid?("name <email")).to be true
+    end
+    it "one invalid and and valid line is true" do
+      expect(NameAndEmail.invalid?("name <email\nname <email>")).to be true
+    end
+  end
 end

--- a/spec/requests/credentials_for_others_spec.rb
+++ b/spec/requests/credentials_for_others_spec.rb
@@ -7,38 +7,92 @@ RSpec.describe "Credentials for others", type: :request do
                                      password: "calufrax")
   end
 
-  it "creates a credential per participant" do
-    post "/credentials_for_others", params: { name: 'name',
-                                              type: 'EducationCredential',
-                                              description: 'description',
-                                              participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
+  context "create" do
+    describe "unhappy path" do
+      it "doesn't create a credential without name" do
+        post "/credentials_for_others", params: { name: '',
+                                                  type: 'EducationCredential',
+                                                  description: 'description',
+                                                  participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
+        expect(response).to render_template(:new)
+        expect(Contact.count).to eq(1)
+        expect(Skill.count).to eq(0)
+      end
+      it "doesn't create a credential with ill-formed participants field" do
+        post "/credentials_for_others", params: { name: 'name',
+                                                  type: 'EducationCredential',
+                                                  description: 'description',
+                                                  participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com" }
+        expect(response).to render_template(:new)
+        expect(Contact.count).to eq(1)
+        expect(Skill.count).to eq(0)
+      end
+    end
+    describe "happy path" do
+      it "creates a credential per participant" do
+        post "/credentials_for_others", params: { name: 'name',
+                                                  type: 'EducationCredential',
+                                                  description: 'description',
+                                                  participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
 
-    expect(Contact.count).to eq(3)
-    expect(Skill.count).to eq(1)
+        expect(Contact.count).to eq(3)
+        expect(Skill.count).to eq(1)
 
-    skill = Skill.first
-    expect(skill.name).to eq('name')
-    expect(skill.skill_type).to eq('EducationCredential')
-    expect(skill.description).to eq('description')
+        skill = Skill.first
+        expect(skill.name).to eq('name')
+        expect(skill.skill_type).to eq('EducationCredential')
+        expect(skill.description).to eq('description')
 
-    expect(Credential.count).to eq(2)
-    participants = Contact.where(email: ['beth.student@example.com', 'bodil.student@example.com'])
-    credentials = Credential.all
-    expect(credentials.map(&:holder)).to match_array(participants)
-    expect(credentials.map(&:skill).uniq).to eq([skill])
-    expect(credentials.map(&:status).uniq).to eq(['authenticated'])
+        expect(Credential.count).to eq(2)
+        participants = Contact.where(email: ['beth.student@example.com', 'bodil.student@example.com'])
+        credentials = Credential.all
+        expect(credentials.map(&:holder)).to match_array(participants)
+        expect(credentials.map(&:skill).uniq).to eq([skill])
+        expect(credentials.map(&:status).uniq).to eq(['authenticated'])
 
-    expect(Authentication.count).to eq(2)
-    authentications = Authentication.all
-    tutor = Contact.where(email: 'cristina.tutor@example.com').first
-    expect(authentications.map(&:credential)).to match_array(credentials)
-    expect(authentications.map(&:authenticator).uniq).to eq([tutor])
-    expect(authentications.map(&:status).uniq).to eq(['accepted'])
+        expect(Authentication.count).to eq(2)
+        authentications = Authentication.all
+        tutor = Contact.where(email: 'cristina.tutor@example.com').first
+        expect(authentications.map(&:credential)).to match_array(credentials)
+        expect(authentications.map(&:authenticator).uniq).to eq([tutor])
+        expect(authentications.map(&:status).uniq).to eq(['accepted'])
 
-    expect(Program.count).to eq(1)
-    program = Program.first
-    expect(program.creator).to eq(tutor)
-    expect(program.skill).to eq(skill)
-    expect(program.credentials.map(&:holder)).to match_array(participants)
+        expect(Program.count).to eq(1)
+        program = Program.first
+        expect(program.creator).to eq(tutor)
+        expect(program.skill).to eq(skill)
+        expect(program.credentials.map(&:holder)).to match_array(participants)
+      end
+    end
+  end
+  context "add participants" do
+    before do
+      post "/credentials_for_others", params: { name: 'name',
+                                                type: 'EducationCredential',
+                                                description: 'description',
+                                                participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
+      @program = Program.first
+    end
+    describe "unhappy path" do
+      it "doesn't add participants with ill-formed field" do
+        post "/credentials_for_others/#{@program.id}/add_participants", params: { participants: "Iolanthe Ill-formed (no email here)"}
+        expect(response).to render_template(:add_participants_form)
+        expect(Contact.count).to eq(3)
+      end
+    end
+    describe "happy path" do
+      it "adds participants" do
+        post "/credentials_for_others/#{@program.id}/add_participants", params: { participants: "Wendy Well-formed <wendy@example.com>"}
+        expect(Contact.count).to eq(4)
+        expect(Credential.count).to eq(3)
+        participants = Contact.where(email: ['beth.student@example.com', 'bodil.student@example.com', 'wendy@example.com'])
+        credentials = Credential.all
+        skill = Skill.first
+        expect(credentials.map(&:holder)).to match_array(participants)
+        expect(credentials.map(&:skill).uniq).to eq([skill])
+        expect(credentials.map(&:status).uniq).to eq(['authenticated'])
+
+      end
+    end
   end
 end

--- a/spec/requests/my_credentials_spec.rb
+++ b/spec/requests/my_credentials_spec.rb
@@ -6,32 +6,82 @@ RSpec.describe "My credentials", type: :request do
                                      email: "anna@example.com",
                                      password: "calufrax")
   end
-  it "creates a credential" do
-    post "/my_credentials", params: { name: 'name',
-                                      type: 'GeneralCredential',
-                                      description: 'description',
-                                      authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
-    expect(Contact.count).to eq(3)
+  context "create" do
+    describe "unhappy path" do
+      it "doesn't create a credential without name" do
+        post "/my_credentials", params: { name: '',
+                                          type: 'GeneralCredential',
+                                          description: 'description',
+                                          authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
+        expect(response).to render_template(:new)
+        expect(Contact.count).to eq(1)
+        expect(Skill.count).to eq(0)
+      end
+      it "doesn't create a credential with ill-formed authenticators field" do
+        post "/my_credentials", params: { name: 'name',
+                                          type: 'GeneralCredential',
+                                          description: 'description',
+                                          authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com" }
+        expect(response).to render_template(:new)
+        expect(Contact.count).to eq(1)
+        expect(Skill.count).to eq(0)
+      end
+    end
+    describe "happy path" do
+      it "creates a credential" do
+        post "/my_credentials", params: { name: 'name',
+                                          type: 'GeneralCredential',
+                                          description: 'description',
+                                          authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
+        expect(Contact.count).to eq(3)
 
-    expect(Skill.count).to eq(1)
-    skill = Skill.first
-    expect(skill.name).to eq('name')
-    expect(skill.skill_type).to eq('GeneralCredential')
-    expect(skill.description).to eq('description')
+        expect(Skill.count).to eq(1)
+        skill = Skill.first
+        expect(skill.name).to eq('name')
+        expect(skill.skill_type).to eq('GeneralCredential')
+        expect(skill.description).to eq('description')
 
-    expect(Credential.count).to eq(1)
-    credential = Credential.first
-    holder = Contact.where(email: 'anna@example.com').first
-    expect(credential.holder).to eq(holder)
-    expect(credential.skill).to eq(skill)
-    expect(credential.status).to eq('authenticated')
-    expect(Authentication.count).to eq(3)
+        expect(Credential.count).to eq(1)
+        credential = Credential.first
+        holder = Contact.where(email: 'anna@example.com').first
+        expect(credential.holder).to eq(holder)
+        expect(credential.skill).to eq(skill)
+        expect(credential.status).to eq('authenticated')
+        expect(Authentication.count).to eq(3)
 
-    holder_authentication = Authentication.where(authenticator: holder).first
-    expect(holder_authentication.status).to eq('accepted')
+        holder_authentication = Authentication.where(authenticator: holder).first
+        expect(holder_authentication.status).to eq('accepted')
 
-    invited_authenticators = Contact.where(email: ['beth@example.com', 'bodil@example.com'])
-    invited_authentications = Authentication.where(authenticator: invited_authenticators)
-    expect(invited_authentications.map(&:status).uniq).to eq(['invited'])
+        invited_authenticators = Contact.where(email: ['beth@example.com', 'bodil@example.com'])
+        invited_authentications = Authentication.where(authenticator: invited_authenticators)
+        expect(invited_authentications.map(&:status).uniq).to eq(['invited'])
+      end
+    end
+  end
+  context "add authenticators" do
+    before do
+      post "/my_credentials", params: { name: 'name',
+                                        type: 'GeneralCredential',
+                                        description: 'description',
+                                        authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
+      @credential = Credential.first
+    end
+    describe "unhappy path" do
+      it "doesn't add authenticators with ill-formed field" do
+        post "/my_credentials/#{@credential.id}/add_authenticators", params: { authenticators: "Iolanthe Ill-formed (no email here)"}
+        expect(response).to render_template(:add_authenticators_form)
+        expect(Contact.count).to eq(3)
+      end
+    end
+    describe "happy path" do
+      it "adds authenticators" do
+        post "/my_credentials/#{@credential.id}/add_authenticators", params: { authenticators: "Wendy Well-formed <wendy@example.com>"}
+        expect(Contact.count).to eq(4)
+        expect(Credential.count).to eq(1)
+        invited_authenticators = Contact.where(email: 'wendy@example.com')
+        invited_authentications = Authentication.where(authenticator: invited_authenticators)
+        expect(invited_authentications.map(&:status).uniq).to eq(['invited'])
+      end
+    end
   end
 end


### PR DESCRIPTION
Also disallow blank names.

Blank authenticator/participant lists are fine (it's an optional field), but not ill-formed ones.

In both cases, as per standard, returns to the form with the erroring fields highlighted and with explanatory messages.