### PR TITLE
Allow both \r\n and \n as line breaks in adding authenticators / part…

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/app/controllers/credentials_for_others_controller.rb
+++ b/app/controllers/credentials_for_others_controller.rb
@@ -10,7 +10,6 @@ class CredentialsForOthersController < CredentialsController
     end
 
     creator = current_user.contact
-    participants = participants_from_params
     skill = Skill.create(name: params[:name],
                          skill_type: params[:type],
                          description: params[:description])
@@ -32,7 +31,7 @@ class CredentialsForOthersController < CredentialsController
 
     credentials_from_participants(creator: creator,
                                   skill: skill,
-                                  participants: participants)
+                                  participants: participants_from_params)
 
     redirect_to action: :index
   end
@@ -63,11 +62,9 @@ class CredentialsForOthersController < CredentialsController
     return head(:forbidden) if program.creator != creator
 
     skill = program.skill
-    participants = participants_from_params
-
     credentials_from_participants(creator: creator,
                                   skill: skill,
-                                  participants: participants)
+                                  participants: participants_from_params)
 
     redirect_to action: :index
   end
@@ -115,11 +112,7 @@ class CredentialsForOthersController < CredentialsController
   private
 
   def participants_from_params
-    participant_params = params[:participants].split("\n").reject(&:empty?)
-    participant_params.map do |row|
-      ne = NameAndEmail.parse(row)
-      Contact.retrieve_or_build(name: ne.name, email: ne.email)
-    end
+    NameAndEmail.retrieve_or_build_contacts(params[:participants])
   end
 
   def credentials_from_participants(creator:, skill:, participants:)

--- a/app/models/name_and_email.rb
+++ b/app/models/name_and_email.rb
@@ -8,15 +8,27 @@ class NameAndEmail
     @email = email
   end
 
-  def self.parse(row)
-    matches = EXPECTED_PATTERN.match(row)
+  def self.retrieve_or_build_contacts(params)
+    lines = split(params)
+    names_and_emails = lines.map { |line| parse(line) }
+    names_and_emails.map do |name_and_email|
+      Contact.retrieve_or_build(name: name_and_email.name, email: name_and_email.email)
+    end
+  end
+
+  def self.split(params)
+    params.split(/\n+|\r+/).reject(&:empty?)
+  end
+
+  def self.parse(line)
+    matches = EXPECTED_PATTERN.match(line)
     new(name: matches[1], email: matches[2])
   end
 
   def self.invalid?(blob)
     return false if blob.empty?
 
-    lines = blob.split("\n").reject(&:empty?)
+    lines = split(blob)
     lines.any? { |l| EXPECTED_PATTERN !~ l }
   end
 end

--- a/spec/models/name_and_email_spec.rb
+++ b/spec/models/name_and_email_spec.rb
@@ -1,28 +1,56 @@
 require "rails_helper"
 
 RSpec.describe NameAndEmail do
+  describe "retrieve_or_build_contacts" do
+    it "one contact already exists: don't create it again" do
+      Contact.create(name: "name1", email: "email1")
+      described_class.retrieve_or_build_contacts("name1 <email1>\nname2 <email2>")
+      expect(Contact.count).to eq(2)
+      expect(Contact.all.map(&:name)).to match_array(%w[name1 name2])
+    end
+    it "no contacts already exist: create both" do
+      described_class.retrieve_or_build_contacts("name1 <email1>\nname2 <email2>")
+      expect(Contact.count).to eq(2)
+      expect(Contact.all.map(&:name)).to match_array(%w[name1 name2])
+    end
+  end
+
+  describe "split" do
+    it "handles lines divided by '\\n' (as in add authenticators / participants)" do
+      expect(described_class.split("name1 <email1>\nname2 <email2>")).to match_array(
+                                                                        ["name1 <email1>",
+                                                                         "name2 <email2>"])
+    end
+    it "handles lines divided by '\\r\\n (as in create credential)" do
+      expect(described_class.split("name1 <email1>\r\nname2 <email2>")).to match_array(
+                                                                        ["name1 <email1>",
+                                                                         "name2 <email2>"])
+    end
+  end
+
   describe "parse" do
     it "name <email>" do
-      actual = NameAndEmail.parse("name <email>")
+      actual = described_class.parse("name <email>")
       expect(actual.name).to eq("name")
       expect(actual.email).to eq ("email")
     end
   end
+
   describe "invalid?" do
     it "empty is false (it's an optional field)" do
-      expect(NameAndEmail.invalid?("")).to be false
+      expect(described_class.invalid?("")).to be false
     end
     it "blank line should resolve to empty" do
-      expect(NameAndEmail.invalid?("\n")).to be false
+      expect(described_class.invalid?("\n")).to be false
     end
     it "one valid line is false" do
-      expect(NameAndEmail.invalid?("name <email>")).to be false
+      expect(described_class.invalid?("name <email>")).to be false
     end
     it "one invalid line is true" do
-      expect(NameAndEmail.invalid?("name <email")).to be true
+      expect(described_class.invalid?("name <email")).to be true
     end
     it "one invalid and and valid line is true" do
-      expect(NameAndEmail.invalid?("name <email\nname <email>")).to be true
+      expect(described_class.invalid?("name <email\nname <email>")).to be true
     end
   end
 end

--- a/spec/requests/credentials_for_others_spec.rb
+++ b/spec/requests/credentials_for_others_spec.rb
@@ -7,13 +7,16 @@ RSpec.describe "Credentials for others", type: :request do
                                      password: "calufrax")
   end
 
+  # Oddly, the app uses '\r\n' as line break in the create case,
+  # but '\n' as the line break in the add participants case.
+  # Tests modified to reflect this pending further investigation
   context "create" do
     describe "unhappy path" do
       it "doesn't create a credential without name" do
         post "/credentials_for_others", params: { name: '',
                                                   type: 'EducationCredential',
                                                   description: 'description',
-                                                  participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
+                                                  participants: "Beth Student <beth.student@example.com>\r\nBodil Student <bodil.student@example.com>" }
         expect(response).to render_template(:new)
         expect(Contact.count).to eq(1)
         expect(Skill.count).to eq(0)
@@ -22,7 +25,7 @@ RSpec.describe "Credentials for others", type: :request do
         post "/credentials_for_others", params: { name: 'name',
                                                   type: 'EducationCredential',
                                                   description: 'description',
-                                                  participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com" }
+                                                  participants: "Beth Student <beth.student@example.com>\r\nBodil Student <bodil.student@example.com" }
         expect(response).to render_template(:new)
         expect(Contact.count).to eq(1)
         expect(Skill.count).to eq(0)
@@ -33,7 +36,7 @@ RSpec.describe "Credentials for others", type: :request do
         post "/credentials_for_others", params: { name: 'name',
                                                   type: 'EducationCredential',
                                                   description: 'description',
-                                                  participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
+                                                  participants: "Beth Student <beth.student@example.com>\r\nBodil Student <bodil.student@example.com>" }
 
         expect(Contact.count).to eq(3)
         expect(Skill.count).to eq(1)
@@ -70,7 +73,7 @@ RSpec.describe "Credentials for others", type: :request do
       post "/credentials_for_others", params: { name: 'name',
                                                 type: 'EducationCredential',
                                                 description: 'description',
-                                                participants: "Beth Student <beth.student@example.com>\nBodil Student <bodil.student@example.com>" }
+                                                participants: "Beth Student <beth.student@example.com>\r\nBodil Student <bodil.student@example.com>" }
       @program = Program.first
     end
     describe "unhappy path" do
@@ -82,16 +85,15 @@ RSpec.describe "Credentials for others", type: :request do
     end
     describe "happy path" do
       it "adds participants" do
-        post "/credentials_for_others/#{@program.id}/add_participants", params: { participants: "Wendy Well-formed <wendy@example.com>"}
-        expect(Contact.count).to eq(4)
-        expect(Credential.count).to eq(3)
-        participants = Contact.where(email: ['beth.student@example.com', 'bodil.student@example.com', 'wendy@example.com'])
+        post "/credentials_for_others/#{@program.id}/add_participants", params: { participants: "Wendy Well-formed <wendy@example.com>\nWanda Well-formed <wanda@example.com>"}
+        expect(Contact.count).to eq(5)
+        expect(Credential.count).to eq(4)
+        participants = Contact.where(email: ['beth.student@example.com', 'bodil.student@example.com', 'wendy@example.com', 'wanda@example.com'])
         credentials = Credential.all
         skill = Skill.first
         expect(credentials.map(&:holder)).to match_array(participants)
         expect(credentials.map(&:skill).uniq).to eq([skill])
         expect(credentials.map(&:status).uniq).to eq(['authenticated'])
-
       end
     end
   end

--- a/spec/requests/my_credentials_spec.rb
+++ b/spec/requests/my_credentials_spec.rb
@@ -6,13 +6,17 @@ RSpec.describe "My credentials", type: :request do
                                      email: "anna@example.com",
                                      password: "calufrax")
   end
+
+  # Oddly, the app uses '\r\n' as line break in the create case,
+  # but '\n' as the line break in the add authenticators case.
+  # Tests modified to reflect this pending further investigation
   context "create" do
     describe "unhappy path" do
       it "doesn't create a credential without name" do
         post "/my_credentials", params: { name: '',
                                           type: 'GeneralCredential',
                                           description: 'description',
-                                          authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
+                                          authenticators: "Beth Example <beth@example.com>\r\nBodil Example <bodil@example.com>" }
         expect(response).to render_template(:new)
         expect(Contact.count).to eq(1)
         expect(Skill.count).to eq(0)
@@ -21,7 +25,7 @@ RSpec.describe "My credentials", type: :request do
         post "/my_credentials", params: { name: 'name',
                                           type: 'GeneralCredential',
                                           description: 'description',
-                                          authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com" }
+                                          authenticators: "Beth Example <beth@example.com>\r\nBodil Example <bodil@example.com" }
         expect(response).to render_template(:new)
         expect(Contact.count).to eq(1)
         expect(Skill.count).to eq(0)
@@ -32,7 +36,7 @@ RSpec.describe "My credentials", type: :request do
         post "/my_credentials", params: { name: 'name',
                                           type: 'GeneralCredential',
                                           description: 'description',
-                                          authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
+                                          authenticators: "Beth Example <beth@example.com>\r\nBodil Example <bodil@example.com>" }
         expect(Contact.count).to eq(3)
 
         expect(Skill.count).to eq(1)
@@ -63,7 +67,7 @@ RSpec.describe "My credentials", type: :request do
       post "/my_credentials", params: { name: 'name',
                                         type: 'GeneralCredential',
                                         description: 'description',
-                                        authenticators: "Beth Example <beth@example.com>\nBodil Example <bodil@example.com>" }
+                                        authenticators: "Beth Example <beth@example.com>\r\nBodil Example <bodil@example.com>" }
       @credential = Credential.first
     end
     describe "unhappy path" do
@@ -75,10 +79,10 @@ RSpec.describe "My credentials", type: :request do
     end
     describe "happy path" do
       it "adds authenticators" do
-        post "/my_credentials/#{@credential.id}/add_authenticators", params: { authenticators: "Wendy Well-formed <wendy@example.com>"}
-        expect(Contact.count).to eq(4)
+        post "/my_credentials/#{@credential.id}/add_authenticators", params: { authenticators: "Wendy Well-formed <wendy@example.com>\nWanda Well-formed <wanda@example.com>"}
+        expect(Contact.count).to eq(5)
         expect(Credential.count).to eq(1)
-        invited_authenticators = Contact.where(email: 'wendy@example.com')
+        invited_authenticators = Contact.where(email: %w[wendy@example.com wanda@example.com])
         invited_authentications = Authentication.where(authenticator: invited_authenticators)
         expect(invited_authentications.map(&:status).uniq).to eq(['invited'])
       end


### PR DESCRIPTION
…icipants

Oddly, it appears that on creating a credential, authenticators / participants param textarea lines are separated by '\r\n', but in adding authenticators / participants later in a different form, the param textarea lines are separated by '\n'.

This should probably be made consistent, but as an interim fix, accept either. Also, because we were doing the split in multiple locations, pull the others into NameAndEmail and only change it there.