### PR TITLE
Tweaks to authenticators list (per Maury's request #2)

### DIFF
--- a/app/views/application/_authentications.erb
+++ b/app/views/application/_authentications.erb
@@ -1,14 +1,31 @@
-<p><b>Authentications:</b>
-    <ul>
-        <% credential.authentications.order(:status).each do |authentication| %>
-            <li>
-                <%= authentication.authenticator.email %> |
-                <%= authentication.status %> |
-                <%= render "explorer_link", id: authentication.submission_transaction_id %>
-                <%= render "explorer_link_revoked", id: authentication.revocation_transaction_id %>
-            </li>
-        <% end %>
-    </ul>
+<% authentications = credential.authentications.order("created_at asc") %>
+<% issuer = authentications.first %>
+<% self_issued = issuer.authenticator_id == credential.holder_id %>
+
+<% non_issuer_authentications = authentications.drop(1) %>
+
+<% if self_issued %>
+    <p><b>Issuer (Self):</b><br>
+<% else %>
+    <p><b>Issuer:</b><br>
+<% end %>
+    <%= issuer.authenticator.email %> |
+    <%= issuer.status %> |
+    <%= render "explorer_link", id: issuer.submission_transaction_id %>
+    <%= render "explorer_link_revoked", id: issuer.revocation_transaction_id %>
 </p>
+
+
+<% if non_issuer_authentications.any? %>
+<p><b>Authentications:</b><br>
+    <% non_issuer_authentications.each do |authentication| %>
+        <%= authentication.authenticator.email %> |
+        <%= authentication.status %> |
+        <%= render "explorer_link", id: authentication.submission_transaction_id %>
+        <%= render "explorer_link_revoked", id: authentication.revocation_transaction_id %>
+        <br>
+    <% end %>
+</p>
+<% end %>
 
 <p><%= link_to "Add Authenticators", add_authenticators_form_my_credential_path(credential.id) %></p>


### PR DESCRIPTION
- separate out issuer from subsequent authentications
- display as Issuer:, and then other Authentications: if present

<img width="722" alt="Screen Shot 2024-01-14 at 11 22 50 AM" src="https://github.com/LearnerShape/ls-auth-ui/assets/18754/471af15f-3bec-4d93-927c-2d85aa757723">
