### PR TITLE
Apply tweaks to authenticators list (Maury's request #2) to public vi…

### DIFF
--- a/app/views/application/_accepted_authentications.erb
+++ b/app/views/application/_accepted_authentications.erb
@@ -1,11 +1,27 @@
-<p><b>Authentications:</b>
-    <ul>
-        <% credential.authentications.is_accepted.each do |authentication| %>
-            <li>
-                <%= authentication.authenticator.email %> |
-                <%= authentication.status %> |
-                <%= render "explorer_link", id: authentication.submission_transaction_id %>
-            </li>
-        <% end %>
-    </ul>
+<% authentications = credential.authentications.is_accepted.order("created_at asc") %>
+<% issuer = authentications.first %>
+<% self_issued = issuer.authenticator_id == credential.holder_id %>
+
+<% non_issuer_authentications = authentications.drop(1) %>
+
+<% if self_issued %>
+    <p><b>Issuer (Self):</b><br>
+<% else %>
+    <p><b>Issuer:</b><br>
+<% end %>
+<%= issuer.authenticator.email %> |
+<%= issuer.status %> |
+<%= render "explorer_link", id: issuer.submission_transaction_id %>
 </p>
+
+
+<% if non_issuer_authentications.any? %>
+    <p><b>Authentications:</b><br>
+        <% non_issuer_authentications.each do |authentication| %>
+            <%= authentication.authenticator.email %> |
+            <%= authentication.status %> |
+            <%= render "explorer_link", id: authentication.submission_transaction_id %>
+            <br>
+        <% end %>
+    </p>
+<% end %>


### PR DESCRIPTION
…ews page

- separate out issuer from subsequent authentications
- display as Issuer:, and then other Authentications: if present

<img width="686" alt="Screen Shot 2024-01-15 at 2 01 22 PM" src="https://github.com/LearnerShape/ls-auth-ui/assets/18754/8dc63816-d54f-4b8e-8b79-6d10bbd53a9f">
