### PR TITLE
Update puma gem version for dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ gem "sprockets-rails"
 gem "pg", "~> 1.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", ">= 5.6.7"
+gem "puma", ">= 6.4.2"
+
 
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     orm_adapter (0.5.0)
     pg (1.5.3)
     public_suffix (5.0.3)
-    puma (6.3.1)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
@@ -261,7 +261,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
-  puma (>= 5.6.7)
+  puma (>= 6.4.2)
   rails (>= 7.0.7.1)
   rails-controller-testing
   rspec-rails


### PR DESCRIPTION
bundler-audit output before:

```
ruby-advisory-db:
  advisories:   846 advisories
  last updated: 2024-01-13 13:27:22 -0800
  commit:       ae2a689a948efe893e272ccca2f32ac73fd9bf6a
Name: puma
Version: 6.3.1
CVE: CVE-2024-21647
GHSA: GHSA-c2f4-cvqm-65w2
Criticality: Medium
URL: https://github.com/puma/puma/security/advisories/GHSA-c2f4-cvqm-65w2
Title: Puma HTTP Request/Response Smuggling vulnerability
Solution: upgrade to '~> 5.6.8', '>= 6.4.2'
```

bundler-audit output after:

```
ruby-advisory-db:
  advisories:   846 advisories
  last updated: 2024-01-13 13:27:22 -0800
  commit:       ae2a689a948efe893e272ccca2f32ac73fd9bf6a
No vulnerabilities found
```
